### PR TITLE
fix incorrect include path for "ouster_ros/os_point.h"

### DIFF
--- a/src/ouster_point_type_adapter_component.cpp
+++ b/src/ouster_point_type_adapter_component.cpp
@@ -3,7 +3,7 @@
 #include "rclcpp_components/register_node_macro.hpp"
 #include "sensor_msgs/point_cloud2_iterator.hpp"
 #include "pcl_conversions/pcl_conversions.h"
-#include "ouster_ros/include/ouster_ros/os_point.h"
+#include "ouster_ros/os_point.h"
 #include "autoware/point_types/types.hpp"
 #include <cmath>
 


### PR DESCRIPTION
@FranzAlbers
 
hi, franz.
i noticed an issue with the include path for `ouster_ros/os_point.h` that causes a build error when installing ros2/humble.

https://github.com/ouster-lidar/ouster-ros/blob/b85d8ee5cd77937821b33f2694b6ffd6c05a6c72/CMakeLists.txt#L40
based on the cmakelists.txt file in the `ouster-ros` repository,
it seems that the `ouster_ros/include` prefix is unnecessary.
including it leads to the following error:

```yaml
fatal error: ouster_ros/include/ouster_ros/os_point.h: No such file or directory
```

i've confirmed this behavior during installation and submitted a fix in this pr. 
could you please take a look when you get a chance? thanks a lot!


